### PR TITLE
Add Dockerfile based on python:3-alpine

### DIFF
--- a/.docker/alpine.dockerfile
+++ b/.docker/alpine.dockerfile
@@ -1,0 +1,24 @@
+FROM python:3-alpine
+
+RUN \
+  echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
+  # Add runtime dependencies
+  && apk add --update jbig2enc@testing ghostscript qpdf \
+    tesseract-ocr unpaper libxml2-dev libxslt-dev zlib-dev \
+    qpdf-dev py3-pybind11@testing leptonica-dev libffi-dev binutils \
+  # Add build dependencies
+  && apk add --virtual build-dependencies build-base git
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pip install .
+
+# Delete build dependencies
+RUN \
+  rm -rf /app && mkdir /app \
+  && apk del build-dependencies \
+  && rm -rf /var/cache/apk/*
+
+ENTRYPOINT ["/usr/local/bin/ocrmypdf"]


### PR DESCRIPTION
This Dockerfile creates a 762MB sized image based on the alpine python3 image.